### PR TITLE
Register as a Compass extension

### DIFF
--- a/lib/base.sass.rb
+++ b/lib/base.sass.rb
@@ -1,3 +1,10 @@
+require 'compass'
+extension_path = File.expand_path(File.join(File.dirname(__FILE__), ".."))
+
+Compass::Frameworks.register('base.sass', :path => extension_path)
+
+
+
 load_path = File.expand_path(File.join(File.dirname(__FILE__), '..', 'stylesheets'))
 
 ENV['SASS_PATH'] = [ENV['SASS_PATH'], load_path].compact.join(File::PATH_SEPARATOR)


### PR DESCRIPTION
This fixes issues with this gem on SassMeister.com.

By properly registering the gem as a Compass extension, the gem's `stylesheets` directory is added to Sass' `load_path`. 

Once you've merged this PR and published a new version of the gem, I'll update SassMeister.com.

Thanks,

Jed 
