### PR TITLE
Support mixin arguments in placeholder-wrapper()

### DIFF
--- a/stylesheets/base.sass/mixins/_placeholder-wrapper.scss
+++ b/stylesheets/base.sass/mixins/_placeholder-wrapper.scss
@@ -1,14 +1,15 @@
 $anonymous-placeholders: ();
 
-@mixin placeholder-wrapper($name) {
-  $times: map-get($anonymous-placeholders, $name) or 0;
+@mixin placeholder-wrapper($name, $args...) {
+  $times: map-get($anonymous-placeholders, ($name, $args)) or 0;
+  $anonymous-placeholders: map-merge($anonymous-placeholders, (($name, $args): $times + 1)) !global;
+  $index: index($anonymous-placeholders, (($name, $args) ($times + 1)));
 
   @if $times == 0 {
-    @at-root %-#{$name} {
+    @at-root %-#{$name}-#{$index} {
       @content;
     }
   }
 
-  @extend %-#{$name};
-  $anonymous-placeholders: map-merge($anonymous-placeholders, ($name: $times + 1)) !global;
+  @extend %-#{$name}-#{$index};
 }


### PR DESCRIPTION
Allows placeholder wrapper to be used with mixins that accept arguments. Example of how this works: http://sassmeister.com/gist/137fbe26c6aa7d9ebeab
